### PR TITLE
detect animate func

### DIFF
--- a/src/leaflet.curve.js
+++ b/src/leaflet.curve.js
@@ -237,7 +237,7 @@ L.Curve = L.Path.extend({
 				this._canvasAnimating = false;
 			}
 		}else{
-			if(this.options.animate){
+			if(this.options.animate && this._path.animate){
 				var length = this._svgSetDashArray();
 				
 				this._path.animate([


### PR DESCRIPTION
ref: https://developer.mozilla.org/en-US/docs/Web/API/Element/animate

Safari not support animate method, so before call animate we need detect it.

Otherwise, Safari will report error.