### PR TITLE
Additional compatibility methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The `L.Curve` class extends `L.Path` so options, events, and methods inherited f
 |------|-------|-----------|
 |setPath(`pathData[]`)|`this`|Replaces the current path with the given array of commands and coordinates.|
 |getPath()|`pathData[]`|Returns array of the commands and coordinates in the path.|
+|setLatLngs(`pathData[]`)|`this`|Alias to method this.setPath(`pathData[]`) using the naming convention of L.Polyline and other Leaflet components.|
 |trace(`samplingDistance[]`)|`latLng[]`|Returns array of points that lie on the curve at the given distances. Sampling distance is a decimal value between 0 and 1 inclusive and is applied to each segment (i.e. command) of the curve. See [DEMO] for example.|
 
 ### License

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elfalem/leaflet-curve",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "A Leaflet plugin for drawing Bézier curves and other complex shapes.",
   "main": "dist/leaflet.curve.js",
   "scripts": {

--- a/src/leaflet.curve.js
+++ b/src/leaflet.curve.js
@@ -9,21 +9,31 @@
 L.Curve = L.Path.extend({
 	options: {
 	},
-	
+
 	initialize: function(path, options){
 		L.setOptions(this, options);
 		this._setPath(path);
 	},
-	
+
+	// Added to follow the naming convention of L.Polyline and other Leaflet component classes:
+	// (https://leafletjs.com/reference-1.6.0.html#polyline-setlatlngs)
+	setLatLngs: function(path) {
+		return this.setPath(path);
+	},
+
+	_updateBounds: function() {
+		// Empty function to satisfy L.Path.setStyle() method
+	},
+
 	getPath: function(){
 		return this._coords;
 	},
-	
+
 	setPath: function(path){
 		this._setPath(path);
 		return this.redraw();
 	},
-	
+
 	getBounds: function() {
 		return this._bounds;
 	},
@@ -32,7 +42,7 @@ L.Curve = L.Path.extend({
 		this._coords = path;
 		this._bounds = this._computeBounds();
 	},
-	
+
 	_computeBounds: function(){
 		var bound = new L.LatLngBounds();
 		var lastPoint;
@@ -113,17 +123,17 @@ L.Curve = L.Path.extend({
 		}
 		return bound;
 	},
-	
+
 	getCenter: function () {
 		return this._bounds.getCenter();
 	},
-	
+
 	_update: function(){
 		if (!this._map) { return; }
-		
+
 		this._updatePath();
 	},
-	
+
 	_updatePath: function() {
 		if(this._usingCanvas){
 			this._updateCurveCanvas();
@@ -194,7 +204,7 @@ L.Curve = L.Path.extend({
 
 		this._latLngToPointFn = this._usingCanvas ? map.latLngToContainerPoint : map.latLngToLayerPoint;
 		if(this._usingCanvas){
-			this._pathSvgElement = document.createElementNS('http://www.w3.org/2000/svg', 'path');			
+			this._pathSvgElement = document.createElementNS('http://www.w3.org/2000/svg', 'path');
 		}
 	},
 
@@ -203,7 +213,7 @@ L.Curve = L.Path.extend({
 			// determine if dash array is set by user
 			this._canvasSetDashArray = !this.options.dashArray;
 		}
-		
+
 		L.Path.prototype.onAdd.call(this, map); // calls _update()
 
 		if(this._usingCanvas){
@@ -239,7 +249,7 @@ L.Curve = L.Path.extend({
 		}else{
 			if(this.options.animate && this._path.animate){
 				var length = this._svgSetDashArray();
-				
+
 				this._path.animate([
 					{strokeDashoffset: length},
 					{strokeDashoffset: 0}
@@ -262,7 +272,7 @@ L.Curve = L.Path.extend({
 	_updateCurveSvg: function(){
 		this._renderer._setPath(this, this._curvePointsToPath(this._points));
 
-		if(this.options.animate){			
+		if(this.options.animate){
 			this._svgSetDashArray();
 		}
 	},
@@ -270,7 +280,7 @@ L.Curve = L.Path.extend({
 	_svgSetDashArray: function(){
 		var path = this._path;
 		var length = path.getTotalLength();
-		
+
 		if(!this.options.dashArray){
 			path.style.strokeDasharray = length + ' ' + length;
 		}
@@ -321,7 +331,7 @@ L.Curve = L.Path.extend({
 
 		var pathString = this._curvePointsToPath(this._points);
 		this._pathSvgElement.setAttribute('d', pathString);
-		
+
 		if(this.options.animate && typeof(TWEEN) === 'object' && this._canvasSetDashArray){
 			this._pathLength = this._pathSvgElement.getTotalLength();
 			this.options.dashArray = this._pathLength + '';
@@ -334,7 +344,7 @@ L.Curve = L.Path.extend({
 			this._resetCanvas();
 		}
 
-		
+
 	},
 
 	_animationCanvasElement: null,
@@ -365,10 +375,10 @@ L.Curve = L.Path.extend({
 	_clearCanvas: function() {
 		this._animationCanvasElement.getContext('2d').clearRect(0, 0, this._animationCanvasElement.width, this._animationCanvasElement.height);
 	},
-  
+
 	_animateCanvas: function(time){
 		TWEEN.update(time);
-	
+
 		var ctx = this._animationCanvasElement.getContext('2d');
 		ctx.clearRect(0, 0, this._animationCanvasElement.width, this._animationCanvasElement.height);
 		ctx.lineDashOffset = this._tweenedObject.offset;


### PR DESCRIPTION
## Description

As discussed in this [issue](https://github.com/elfalem/Leaflet.curve/issues/25), this pull request adds 2 methods to Leaflet.curve with supporting documentation and an npm version update. These changes are backwards compatible.

## Changes

-  Add the `L.curve.setLatLngs()` method as an alias to `L.curve.setPath()` to more closely follow the naming convention observed in [L.Polyline](https://leafletjs.com/reference-1.6.0.html#polyline-setlatlngs) and other Leaflet components (ex. [L.CircleMarker](https://leafletjs.com/reference-1.6.0.html#circlemarker-setlatlng))
- Add method `L.curve.setLatLngs()` to README.md for visibility
- Update package minor version (new method was added without breaking backwards compatibility)

## Plans for merge

Once @elfalem has reviewed and approved the following changes, I will merge the pull request unless I see a comment requesting further modification. After merging I will close the related [issue](https://github.com/elfalem/Leaflet.curve/issues/25).