### PR TITLE
Added type support for Leaflet Curve class and (curve) function

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.0",
   "description": "A Leaflet plugin for drawing Bézier curves and other complex shapes.",
   "main": "dist/leaflet.curve.js",
+  "types": "types/leaflet.curve.d.ts",
   "scripts": {
     "build": "webpack"
   },

--- a/types/leaflet.curve.d.ts
+++ b/types/leaflet.curve.d.ts
@@ -1,0 +1,22 @@
+export type CurveLatLngExpression = [number, number] | [number]
+export type CurveSVGCommand = 'M' | 'L' | 'H' | 'V' | 'C' | 'S' | 'Q' | 'T' | 'Z'
+
+export type CurvePathDataElement = CurveLatLngExpression | CurveSVGCommand
+export type CurvePathData = CurvePathDataElement[]
+
+declare module "leaflet" {
+    export interface CurveOptions extends PathOptions {
+        animate?: KeyframeAnimationOptions | number
+    }
+
+    export class Curve extends Path {
+        constructor(pathData: CurvePathData, options: CurveOptions);
+
+        setPath(pathData: CurvePathData): this;
+        getPath(): CurvePathData;
+        setLatLngs(pathData: CurvePathData): this;
+        trace(samplingDistance: number[]): LatLng[]
+    }
+
+    export function curve(pathData: CurvePathData, options: CurveOptions): Curve
+}

--- a/types/leaflet.curve.d.ts
+++ b/types/leaflet.curve.d.ts
@@ -1,22 +1,41 @@
-export type CurveLatLngExpression = [number, number] | [number]
-export type CurveSVGCommand = 'M' | 'L' | 'H' | 'V' | 'C' | 'S' | 'Q' | 'T' | 'Z'
+import { PathOptions, Path, LatLng } from "leaflet";
 
-export type CurvePathDataElement = CurveLatLngExpression | CurveSVGCommand
-export type CurvePathData = CurvePathDataElement[]
+// Leaflet.Curve accepts two latlng types,
+// [lat: number, lng: number] for commands M, L, C, S, Q, T and
+// [lat/lng: number] for commands H, V
+export type CurveLatLngExpression = [number, number] | [number];
 
+// SVG Command Types
+export type CurveSVGCommand =
+    | "M"
+    | "L"
+    | "H"
+    | "V"
+    | "C"
+    | "S"
+    | "Q"
+    | "T"
+    | "Z";
+
+// PathData consists of SVG command followed by their lat/lng parameters
+export type CurvePathDataElement = CurveLatLngExpression | CurveSVGCommand;
+export type CurvePathData = CurvePathDataElement[];
+
+// Extending existing leaflet module to add Curve class and curve function
 declare module "leaflet" {
     export interface CurveOptions extends PathOptions {
-        animate?: KeyframeAnimationOptions | number
+        animate?: KeyframeAnimationOptions | number;
     }
 
     export class Curve extends Path {
         constructor(pathData: CurvePathData, options: CurveOptions);
 
+        // Public functions
         setPath(pathData: CurvePathData): this;
         getPath(): CurvePathData;
         setLatLngs(pathData: CurvePathData): this;
-        trace(samplingDistance: number[]): LatLng[]
+        trace(samplingDistance: number[]): LatLng[];
     }
 
-    export function curve(pathData: CurvePathData, options: CurveOptions): Curve
+    export function curve(pathData: CurvePathData, options: CurveOptions): Curve;
 }


### PR DESCRIPTION
A new `leaflet.curve.d.ts` file has been created in the `types` folder. This declaration file extends the `leaflet` module defined already at [@types/leaflet](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/leaflet) and uses its existing type definitions to include two new `Curve` class and `curve` function. This is meant to be a first draft. Feel free to let me know if there any other changes, stylistic modifications you would like me to make 😃  Thanks.