### PR TITLE
add getLatLngs method

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The `L.Curve` class extends `L.Path` so options, events, and methods inherited f
 |setPath(`pathData[]`)|`this`|Replaces the current path with the given array of commands and coordinates.|
 |getPath()|`pathData[]`|Returns array of the commands and coordinates in the path.|
 |setLatLngs(`pathData[]`)|`this`|Alias to method this.setPath(`pathData[]`) using the naming convention of L.Polyline and other Leaflet components.|
+|getLatLngs()|`pathData[]	`|Alias to method this.getPath() using the naming convention of L.Polyline and other Leaflet components.|
 |trace(`samplingDistance[]`)|`latLng[]`|Returns array of points that lie on the curve at the given distances. Sampling distance is a decimal value between 0 and 1 inclusive and is applied to each segment (i.e. command) of the curve. See [DEMO] for example.|
 
 ### License

--- a/src/leaflet.curve.js
+++ b/src/leaflet.curve.js
@@ -20,18 +20,19 @@ L.Curve = L.Path.extend({
 	setLatLngs: function(path) {
 		return this.setPath(path);
 	},
-
+	getLatLngs: this.getPath,
+	
 	_updateBounds: function() {
 		var tolerance = this._clickTolerance();
 		var tolerancePoint = new L.Point(tolerance, tolerance);
-
+		
 		//_pxBounds is critical for canvas renderer, used to determine area that needs redrawing
 		this._pxBounds = new L.Bounds([
 			this._rawPxBounds.min.subtract(tolerancePoint),
 			this._rawPxBounds.max.add(tolerancePoint)
 		]);
 	},
-
+	
 	getPath: function(){
 		return this._coords;
 	},

--- a/types/leaflet.curve.d.ts
+++ b/types/leaflet.curve.d.ts
@@ -33,6 +33,7 @@ declare module "leaflet" {
         // Public functions
         setPath(pathData: CurvePathData): this;
         getPath(): CurvePathData;
+        getLatLngs(): CurvePathData;
         setLatLngs(pathData: CurvePathData): this;
         trace(samplingDistance: number[]): LatLng[];
     }


### PR DESCRIPTION
Following the same logic as setLatLngs(`pathData[]`), added `getLatLngs` to get the array of commands to draw the curve.