### PR TITLE
bugfix on canvas, when the curve is empty

### DIFF
--- a/src/leaflet.curve.js
+++ b/src/leaflet.curve.js
@@ -293,6 +293,7 @@ L.Curve = L.Path.extend({
 
 	// Needed by the `Canvas` renderer for interactivity
 	_containsPoint: function(layerPoint) {
+		if (!this._bounds.isValid()) return false;
 		return this._bounds.contains(this._map.layerPointToLatLng(layerPoint));
 	},
 


### PR DESCRIPTION
When we create an empty curve using canvas renderer, the `_containsPoint` function tries to check if the invalid bounds contain the point, which throws an error.